### PR TITLE
Adding time travel support for Torii

### DIFF
--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -342,6 +342,14 @@ pub struct SqlOptions {
     )]
     pub historical: Vec<String>,
 
+    /// Whether to enable time_travel tracking for models
+    #[arg(
+        long = "sql.time_travel",
+        default_value_t = false,
+        help = "Whether to enable time_travel tracking for models."
+    )]
+    pub time_travel: bool,
+
     /// The page size to use for the database. The page size must be a power of two between 512 and
     /// 65536 inclusive.
     #[arg(
@@ -366,6 +374,7 @@ impl Default for SqlOptions {
             all_model_indices: false,
             model_indices: None,
             historical: vec![],
+            time_travel: false,
             page_size: DEFAULT_DATABASE_PAGE_SIZE,
             cache_size: DEFAULT_DATABASE_CACHE_SIZE,
         }

--- a/crates/torii/runner/src/lib.rs
+++ b/crates/torii/runner/src/lib.rs
@@ -183,6 +183,7 @@ impl Runner {
                 all_model_indices: self.args.sql.all_model_indices,
                 model_indices: self.args.sql.model_indices.unwrap_or_default(),
                 historical_models: self.args.sql.historical.clone().into_iter().collect(),
+                time_travel: self.args.sql.time_travel,
             },
         )
         .await?;


### PR DESCRIPTION
Added time travel support for Torii indexer. 
- Creates _history table for each of the main tables
- Uses timestamp to track point in time changes
- Uses triggers on tables 
- Code changes are to create new _history table and also set a trigger up.
- Uses SQLite itself as it is the DB of choice.

# Description

<!--
A description of what this PR is solving.
-->

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
